### PR TITLE
fix ZSH issue (bash also tested)

### DIFF
--- a/mono-snapshot
+++ b/mono-snapshot
@@ -4,7 +4,8 @@
 # Copyright 2012 Jo Shields
 # Licensed under WTFPL v2
 
-if [ "$(expr \"$0\" : \".*sh\")" -eq "0" ]
+shtest=$(expr "$0" : ".*sh")
+if [ "$shtest" -eq "0" ]
 then
         echo "This script will help you to set up your environment to use a"
 	echo "snapshot package of Mono. To use it, run:"
@@ -20,7 +21,8 @@ then
 fi
 
 VER=$1
-if [ "x${VER}" == "x" ]
+vertest=$(expr length "$VER")
+if [[ "$vertest" -eq "0" ]]
 then
 	echo "You must specify a snapshot to use"
 	return 1
@@ -42,4 +44,3 @@ else
 	echo "You must specify a valid app version (no app ${VER} found)"
 	return 1
 fi
-


### PR DESCRIPTION
symptom:

% . mono-snapshot mono
/usr/bin/mono-snapshot:7: no matches found: ".*sh"
This script will help you to set up your environment to use a
snapshot package of Mono. To use it, run:

```
    . mono-snapshot APP/VER
```

You have the following possible combinations of APP/VER:

```
    mono/20150528140749
```

Calling APP without specifying VER will load the latest version

problem: quote escaping in zsh is not the same as in bash

intermediate variables solve this
