### PR TITLE
Second fix to handle wildcard in both zsh and bash

### DIFF
--- a/mono-snapshot
+++ b/mono-snapshot
@@ -4,7 +4,7 @@
 # Copyright 2012 Jo Shields
 # Licensed under WTFPL v2
 
-shtest=$(expr "$0" : ".*sh")
+shtest=$(expr \"$0\" : '.*sh')
 if [ "$shtest" -eq "0" ]
 then
         echo "This script will help you to set up your environment to use a"


### PR DESCRIPTION
Simple quotes to enclose wildcard
